### PR TITLE
Fix patches include

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,13 @@ setup(
     keywords="seal5",
     name="seal5",
     packages=find_packages(include=["seal5", "seal5.*"]),
-    package_data={"seal5": resource_files("resources")},
+    package_data={
+        "seal5": [
+            "resources/*",
+            "resources/patches/*",
+            "resources/patches/llvm/*",
+        ],
+    },
     test_suite="tests",
     tests_require=requirements,
     url="https://github.com/tum-ei-eda/seal5",


### PR DESCRIPTION
When running setup first time, patches in llvm folder are not build/installed when running `python setup.py build/install`.
So the demo project fails.
